### PR TITLE
Introduce escaping of '.' characters in labels

### DIFF
--- a/test/plugin/test_out_tag_normaliser.rb
+++ b/test/plugin/test_out_tag_normaliser.rb
@@ -21,10 +21,37 @@ class TagNormaliserOutputTest < Test::Unit::TestCase
     d = create_driver(config)
     d.run(default_tag: 'test') do
       d.feed("tag1", event_time, record.dup)
+    end
+    events = d.events
+    puts events
+
+    assert_equal("cluster.default.understood-butterfly-nginx-logging-demo-7dcdcfdcd7-h7p9n.nginx", events[0][0])
+  end
+
+  test "escape_test" do
+    config = %[
+      format cluster.${namespace_name}.${labels.app}.${labels.app\\.tier}.${labels.app\\.kubernetes\\.io/managed-by}
+    ]
+    record = {
+        "log" => "Example",
+        "kubernetes" => {
+            "pod_name" => "understood-butterfly-nginx-logging-demo-7dcdcfdcd7-h7p9n",
+            "namespace_name" => "default",
+            "labels" => {
+              "app" => "nginx",
+              "app.tier" => "frontend",
+              "app.kubernetes.io/managed-by" => "helm"
+            }
+        }
+    }
+    d = create_driver(config)
+    d.run(default_tag: 'test') do
       d.feed("tag1", event_time, record.dup)
     end
     events = d.events
     puts events
+
+    assert_equal("cluster.default.nginx.frontend.helm", events[0][0])
   end
 
   private


### PR DESCRIPTION
The current implementation cannot handle Kubernetes labels that contain `.` characters, e.g. `app.kubernetes.io/name`.
This PR proposes an escape character (`\`) for this use case.
Example format string:
`cluster.${app\.kubernetes\.io/name}`